### PR TITLE
Added function to strip extention from file name

### DIFF
--- a/src/utils/render-utils.ts
+++ b/src/utils/render-utils.ts
@@ -58,7 +58,7 @@ export async function renderSlot(plugin: Plugin, settings: TierListSettings, slo
             addTitle(slot, altEl.getAttr('alt') || '');
         }
         else {
-            slot.setAttr('title', altEl.getAttr('alt'));
+            slot.setAttr('title', stripExtension(altEl.getAttr('alt')));
         }
     }
 
@@ -85,6 +85,10 @@ function addTitle(parentElement: HTMLElement, text: string) {
         text: text,
         cls: 'tier-list-title-text',
     });
+}
+
+function stripExtension(filename: string | null): string {
+    return filename ? filename.replace(/\.[^/.]+$/, "") : "";
 }
 
 function findTextNodeRecursive(element: HTMLElement): Text | null {


### PR DESCRIPTION
Hi,
I loved your plugin and started using it.
My images are mostly `.png` or `.jpeg` and while putting those in tier list and hover to see the title, the file name extentions annoyed me a bit. So I wrote a function to **strip file name extention** and I think extension is not useful for tiers.

I just debugged and inserted the function where i thought the title set happened. 
